### PR TITLE
migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.0.0
+
+- Migrate to null safety.
+
 ## 1.1.0
 
 - Updated code to 2.7 Dart and latest `pedantic` lints. 

--- a/lib/ulid.dart
+++ b/lib/ulid.dart
@@ -23,7 +23,7 @@ class Ulid {
   }
 
   /// Create a  [Ulid] instance.
-  factory Ulid({int millis}) {
+  factory Ulid({int? millis}) {
     final data = Uint8List(16);
     var ts = millis ?? DateTime.now().millisecondsSinceEpoch;
     for (var i = 5; i >= 0; i--) {
@@ -52,9 +52,7 @@ class Ulid {
 
   /// Creates a new instance form the provided bytes buffer.
   factory Ulid.fromBytes(List<int> bytes) {
-    if (bytes == null ||
-        bytes.length != 16 ||
-        bytes.any((b) => b > 256 || b < 0)) {
+    if (bytes.length != 16 || bytes.any((b) => b > 256 || b < 0)) {
       throw ArgumentError.value(bytes, 'bytes', 'Invalid input.');
     }
     return Ulid._(Uint8List.fromList(bytes));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,11 +2,11 @@ name: ulid
 description: >
   Lexicographically sortable, 128-bit identifier (UUID) with 48-bit timestamp and 80 random bits.
   Canonically encoded as a 26 character string, as opposed to the 36 character UUID.
-version: 1.1.0
+version: 2.0.0
 homepage: https://github.com/agilord/ulid
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   pedantic: ^1.0.0


### PR DESCRIPTION
Migrate to null safety. Changes are very minor.

As this is a breaking change, I have also bumped the version to `2.0.0`

Thank you for your time reviewing this PR and maintaining this important project!